### PR TITLE
Add command line arguments

### DIFF
--- a/programs/module_using_sys.txt
+++ b/programs/module_using_sys.txt
@@ -1,4 +1,4 @@
-$ python module_using_sys.py
+$ python module_using_sys.py we are arguments
 The command line arguments are:
 module_using_sys.py
 we


### PR DESCRIPTION
Arguments are missing from the command line in the sample.
