### PR TITLE
Update sample code of `dir()` function

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -146,19 +146,19 @@ $ python
 # get names of attributes for current module
 >>> dir()
 ['__builtins__', '__doc__',
-'__name__', '__package__']
+'__name__', '__package__', 'sys']
 
 # create a new variable 'a'
 >>> a = 5
 
 >>> dir()
-['__builtins__', '__doc__', '__name__', '__package__', 'a']
+['__builtins__', '__doc__', '__name__', '__package__', 'sys', 'a']
 
 # delete/remove a name
 >>> del a
 
 >>> dir()
-['__builtins__', '__doc__', '__name__', '__package__']
+['__builtins__', '__doc__', '__name__', '__package__', 'sys']
 ```
 
 **How It Works**


### PR DESCRIPTION
The `sys` module is imported in sample code while its name not listed by the `dir()` call. The PR updates the sample code to be consistent with the following description:

> Notice that the list of imported modules is also part of this list.