### PR TITLE
update: fix internal link for 'classes'

### DIFF
--- a/oop.md
+++ b/oop.md
@@ -32,7 +32,7 @@ You must be wondering how Python gives the value for `self` and why you don't ne
 
 This also means that if you have a method which takes no arguments, then you still have to have one argument - the `self`.
 
-## Classes {#class}
+## Classes {#classes}
 
 The simplest class possible is shown in the following example (save as `oop_simplestclass.py`).
 


### PR DESCRIPTION
This could be a solution for the broken link in https://python.swaroopch.com/basics.html#data-types (`... our own types using [classes](./oop.md#classes)`.