### PR TITLE
Fix inconsistency between code and output.txt

### DIFF
--- a/programs/function_varargs.txt
+++ b/programs/function_varargs.txt
@@ -3,6 +3,6 @@ a 10
 single_item 1
 single_item 2
 single_item 3
-Inge 1560
-John 2231
 Jack 1123
+John 2231
+Inge 1560


### PR DESCRIPTION
The order of output key pairs is reversed.

Related code example:
total(10,1,2,3,Jack=1123,John=2231,Inge=1560)