### PR TITLE
more.md: removed 2 dead links ( python2 vs 3)

### DIFF
--- a/more.md
+++ b/more.md
@@ -163,10 +163,9 @@ See:
 
 See:
 
-- ["Six" library](http://pythonhosted.org/six/)
+
 - [Porting to Python 3 Redux by Armin](http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/)
 - [Python 3 experience by PyDanny](http://pydanny.com/experiences-with-django-python3.html)
-- [Official Django Guide to Porting to Python 3](https://docs.djangoproject.com/en/dev/topics/python3/)
 - [Discussion on What are the advantages to python 3.x?](http://www.reddit.com/r/Python/comments/22ovb3/what_are_the_advantages_to_python_3x/)
 
 ## Summary


### PR DESCRIPTION
those links in the python2 vs python3 section are dead, removed:
- ["Six" library](http://pythonhosted.org/six/)
- [Official Django Guide to Porting to Python 3](https://docs.djangoproject.com/en/dev/topics/python3/)