### PR TITLE
what_next.md: changed "buy hardcopy" link to working site

### DIFF
--- a/what_next.md
+++ b/what_next.md
@@ -8,7 +8,7 @@ I would suggest that you tackle this problem:
 
 This is fairly easy if you think about it in terms of all the various stuff that we have come across till now. If you still want directions on how to proceed, then here's a hint [^1].
 
-Once you are able to do this, you can claim to be a Python programmer. Now, immediately [send me an email]({{ book.contactUrl }}) thanking me for this great book ;-). This step is optional but recommended. Also, please consider [buying a printed copy]({{ book.buyBookUrl }}) to support the continued development of this book.
+Once you are able to do this, you can claim to be a Python programmer. Now, immediately [send me an email]({{ book.contactUrl }}) thanking me for this great book ;-). This step is optional but recommended. Also, please consider [buying a printed copy](https://store.pothi.com/book/swaroop-c-h-byte-python/>) to support the continued development of this book.
 
 If you found that program easy, here's another one:
 


### PR DESCRIPTION
it seems that all the "buy the book" links inside "a byte of python" lead to no-longer existing sites. From "swaroop.com" there are still links to buy the book. one is a dead link to a hulu.com site, the other link still seems to work: https://store.pothi.com/book/swaroop-c-h-byte-python/>

i suggest to use this link until the "buy book" links from the main site are functional again.

(i have no idea if the pothi.com link works at all or works with shipping outside india)